### PR TITLE
chore: update create user script to fix issue in latest version of MYSQL

### DIFF
--- a/scripts/CreateUser.sql
+++ b/scripts/CreateUser.sql
@@ -1,2 +1,2 @@
 CREATE USER 'user'@'%' IDENTIFIED BY 'password';
-GRANT ALL ON *.* TO 'user'@'%';
+GRANT ALL PRIVILEGES ON *.* TO 'user'@'%';


### PR DESCRIPTION
# MySql connection issues on M1 Macs

M1 Macs using the mysql/mysql-server:latest-aarch64 docker image were having issue where they were unable to connect to mysql as `user`. This PR fixes the issue on M1, however needs to be tested on a non M! computer to ensure everything is working as expected.